### PR TITLE
Guard release workflow to tags/dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   validate:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
     name: Validate version alignment
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary\n- gate validate/build jobs so release workflow only runs on tag pushes or manual dispatch\n- prevents branch pushes (e.g., main merges) from tripping tag validation\n\n## Testing\n- not run (workflow change only)