### PR TITLE
chore: enable Renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "automerge": true,
+  "automergeType": "pr"
 }


### PR DESCRIPTION
## Summary
- Enable automerge in Renovate so dependency PRs merge automatically when CI passes
- Dependabot security updates should be disabled on the repo since Renovate handles these bumps

## Test plan
- [ ] Verify next Renovate PR auto-merges after CI passes